### PR TITLE
Support NHC on Ubuntu OS

### DIFF
--- a/install-nhc.sh
+++ b/install-nhc.sh
@@ -7,7 +7,15 @@ wget -O nhc-$NHC_VERSION.tar.xz https://github.com/mej/nhc/releases/download/1.4
 tar -xf nhc-$NHC_VERSION.tar.xz
 
 pushd lbnl-nhc-$NHC_VERSION
-./configure --prefix=/usr --sysconfdir=/etc --libexecdir=/usr/libexec
+
+. /etc/os-release
+case $ID in
+  ubuntu)  
+    LIBEXEDIR=/usr/lib;;
+  *) 
+    LIBEXEDIR=/usr/libexec;;
+esac
+./configure --prefix=/usr --sysconfdir=/etc --libexecdir=$LIBEXEDIR
 
 sudo make test
 echo -e "\n"


### PR DESCRIPTION
Added support for Ubuntu OS

- On Ubuntu OS NHC searches in /usr/lib and not /usr/libexec
- Integration with SLURM, NHC looks for scripts in /usr/lib/nhc (which currently do not exit and SLURM integration fails)