### PR TITLE
Update run-health-checks.sh for case error

### DIFF
--- a/run-health-checks.sh
+++ b/run-health-checks.sh
@@ -75,7 +75,7 @@ OUTPUT_PATH=$(realpath -m "$OUTPUT_PATH")
 # If a custom configuration isn't specified, detect the VM SKU and use the appropriate conf file
 if [ -z "$CONF_FILE" ]; then
     echo "No custom conf file specified, detecting VM SKU..."
-    SKU=$( curl -H Metadata:true --max-time 10 -s "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-01-01&format=text" | sed 's/Standard_//')
+    SKU=$( curl -H Metadata:true --max-time 10 -s "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-01-01&format=text" | sed 's/standard_//')
     SKU="${SKU,,}"
     CONF_DIR="$(dirname "${BASH_SOURCE[0]}")/conf/"
     CONF_FILE="$CONF_DIR/$SKU.conf"


### PR DESCRIPTION
I don't know if this is just HBv3 or all metadata returns, the "Standard" comes back as standard". Here's the raw output:

<img width="917" alt="Screenshot 2023-12-26 at 4 09 01 PM" src="https://github.com/Azure/azurehpc-health-checks/assets/74573600/4308d8a3-b2a6-4ff6-a936-8799066f75b4">
