### PR TITLE
Added Test Completion output and nvsmi output to verbose

### DIFF
--- a/customTests/azure_common.nhc
+++ b/customTests/azure_common.nhc
@@ -9,6 +9,36 @@ function get_sku(){
    return 0
 }
 
+function pass(){
+   IFS=$' \t\n'
+   local RET="$1"
+   shift
+
+   CHECK_SUCCESS=0
+
+   if [[ -z "$CHECK" ]] && CHECK="$FUNCNAME $*"; then
+      if [[ -n "$NHC_RM" && "$MARK_OFFLINE" -eq 1 && "$PASS_CNT" -eq 0 ]]; then
+        if [[ "${CHECK:0:5}" == "pass " ]]; then
+            CHECK="$OFFLINE_NODE '$HOSTNAME' '$*'"
+            eval $OFFLINE_NODE "'$HOSTNAME'" "'$*'"
+            CHECK="$FUNCNAME $*"
+        else
+            eval $OFFLINE_NODE "'$HOSTNAME'" "'$*'"
+        fi
+      fi
+   fi
+
+   if [[ -n "$LOGFILE" ]]; then
+      echo "SUCCESS:  $NAME:  Health check passed:  $*"
+      oecho "SUCCESS:  $NAME:  Health check passed:  $*"
+   fi
+
+   if [[ "$NHC_CHECK_ALL" == "0" ]]; then
+      ((PASS_CNT++))
+      return 0
+   fi
+}
+
 function check_all_reduce_dependencies() {
    if [[ ! -f $ALL_REDUCE_PATH ]]; then
       die 1 "$FUNCNAME: all reduce executable path: $ALL_REDUCE_PATH not found. Ensure nccl-tests is installed and built in."

--- a/customTests/azure_cpu_stream.nhc
+++ b/customTests/azure_cpu_stream.nhc
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /etc/nhc/scripts/azure_common.nhc
+
 # Run Stream
 
 EXE_DIR=$AZ_NHC_ROOT/bin
@@ -123,6 +125,8 @@ function check_cpu_stream(){
             return 1
         fi
     done
+
+    pass 0 "$FUNCNAME: Stream tests passed"
     return 0
 
 }

--- a/customTests/azure_gpu_amd_xgmi.nhc
+++ b/customTests/azure_gpu_amd_xgmi.nhc
@@ -20,4 +20,7 @@ check_gpu_xgmi(){
             return 1
         fi
     done
+
+    pass 0 "$FUNCNAME: No xgmi errors found on any GPU"
+    return 0
 }

--- a/customTests/azure_gpu_app_clocks.nhc
+++ b/customTests/azure_gpu_app_clocks.nhc
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /etc/nhc/scripts/azure_common.nhc
+
 # Check if application GPU clock frequencies are set to their maximum values, if not will attempt to set them.
 
 GPU_QUERY_CLOCKS="clocks.max.memory,clocks.applications.memory,clocks.max.graphics,clocks.applications.graphics"
@@ -42,5 +44,7 @@ function check_app_gpu_clocks() {
          dbg "GPU Id $i: max application GPU clocks are already set, GPU memory is  ${gpu_freq_out_line[0]} MHz and GPU graphics is ${gpu_freq_out_line[2]} MHz"
       fi
 done
+
+pass 0 "$FUNCNAME: Application GPU clock frequencies set to max"
 return 0
 }

--- a/customTests/azure_gpu_bandwidth.nhc
+++ b/customTests/azure_gpu_bandwidth.nhc
@@ -106,6 +106,8 @@ function evaluate_nvBW_result(){
             done
         done
     done
+
+    pass 0 "$FUNCNAME: NVBandwidth Tests Successful"
     return 0
 }
 
@@ -175,7 +177,8 @@ function check_nvBW_gpu_bw()
     fi
 
     evaluate_nvBW_result $EXP_CUDA_BW $EXP_P2P_BW
- 
+    
+    pass 0 "$FUNCNAME: GPU bandwidth Tests with NVBandwidth passed"
     return 0
 }
 
@@ -323,6 +326,7 @@ function check_rocm_gpu_bw(){
         return 1
     fi
 
+    pass 0 "$FUNCNAME: ROCm GPU bandwidth test passed"
     return 0
 }
 
@@ -357,5 +361,6 @@ function check_gpu_bw(){
         die 1 -e "$FUNCNAME: No GPUs found!"
 	fi
 
+    pass 0 "$FUNCNAME: GPU Bandiwdth Tests Passed"
     return 0
 }

--- a/customTests/azure_gpu_count.nhc
+++ b/customTests/azure_gpu_count.nhc
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+source /etc/nhc/scripts/azure_common.nhc
+
 function check_gpu_count() {
    EXPECTED_NUM_GPU="$1"
    GPU_TYPE="$2"
@@ -18,5 +21,7 @@ function check_gpu_count() {
      die 1 -e "$FUNCNAME: Expected to see $EXPECTED_NUM_GPU but found $gpu_count"
      return 1
    fi
+
+   pass 0 "$FUNCNAME: Expected $EXPECTED_NUM_GPU and found $gpu_count"
    return 0
 }

--- a/customTests/azure_gpu_ecc.nhc
+++ b/customTests/azure_gpu_ecc.nhc
@@ -1,10 +1,11 @@
 #!/bin/bash
 
+source /etc/nhc/scripts/azure_common.nhc
+
 # Check for GPU ECC errors
 
 GPU_REMAPPED_ROWS_QUERY="remapped_rows.pending,remapped_rows.failure,remapped_rows.uncorrectable"
 GPU_QUERY="ecc.errors.uncorrected.volatile.sram,ecc.errors.uncorrected.aggregate.sram,ecc.errors.uncorrected.volatile.dram,ecc.errors.uncorrected.aggregate.dram,ecc.errors.corrected.volatile.sram,ecc.errors.corrected.aggregate.sram,ecc.errors.corrected.volatile.dram,ecc.errors.corrected.aggregate.dram"
-
 
 function collect_ecc_data() {
    ECC_TYPE=$1
@@ -144,6 +145,7 @@ function check_gpu_ecc() {
       check_ecc $ecc_error_threshold $ecc_sram_threshold
    fi
 
+   pass 0 "$FUNCNAME: ECC checks passed"
    return 0
 }
 

--- a/customTests/azure_gpu_nvlink.nhc
+++ b/customTests/azure_gpu_nvlink.nhc
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /etc/nhc/scripts/azure_common.nhc
+
 function check_nvlink_status(){
     # Check if nvlink is enabled
     num_gpus=$(nvidia-smi --list-gpus | wc -l)
@@ -29,5 +31,7 @@ function check_nvlink_status(){
             dbg "$FUNCNAME: GPU $gpu_id has all nvlinks active."
         fi
     done
+
+    pass 0 "$FUNCNAME: NVLink is enabled and GPU $gpu_id has all nvlinks active"
     return 0
 }

--- a/customTests/azure_gpu_persistence.nhc
+++ b/customTests/azure_gpu_persistence.nhc
@@ -1,9 +1,10 @@
 #!/bin/bash
 
+source /etc/nhc/scripts/azure_common.nhc
+
 # Check GPU persistence mode, if not enabled, attempt to enable.
 
 PERSISTENCE_GPU_QUERY="persistence_mode"
-
 
 function collect_persistence_data() {
 
@@ -39,5 +40,7 @@ function check_gpu_persistence() {
          dbg "$FUNCNAME: GPU id $i: Persistence mode is already enabled"
       fi
 done
+
+pass 0 "$FUNCNAME: GPU Persistence mode is enabled"
 return 0
 }

--- a/customTests/azure_gpu_vbios.nhc
+++ b/customTests/azure_gpu_vbios.nhc
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+source /etc/nhc/scripts/azure_common.nhc
+
 function check_vbios_version() {
     expected_version="$1"
     uniq_vbios_versions=$(nvidia-smi -q | grep "VBIOS Version" | cut -d ':' -f 2 | sed 's/ //g' | uniq)
@@ -8,4 +11,6 @@ function check_vbios_version() {
     elif ! echo "${uniq_vbios_versions[@]}" | grep -qw "$expected_version"; then
         die 1 "$FUNCNAME: GPU VBIOS version does not match the expected '$expected_version', instead got '${uniq_vbios_versions[@]}'"
     fi
+
+    pass 0 "$FUNCNAME: GPU VBIOS version matches expected '$expected_version'"
 }

--- a/customTests/azure_gpu_xid.nhc
+++ b/customTests/azure_gpu_xid.nhc
@@ -2,6 +2,8 @@
 
 # reference this link for info on XID error codes: https://docs.nvidia.com/deploy/xid-errors/index.html
 
+source /etc/nhc/scripts/azure_common.nhc
+
 # Check for the following GPU Xid errors in dmesg
 XID_EC="48 56 57 58 62 63 64 65 68 69 73 74 79 80 81 92 119 120"
 GPU_XID_TEST="GPU Xid errors detected"
@@ -32,6 +34,7 @@ function check_gpu_xid()
       done
    else
       dbg "No GPU Xid error found in dmesg"
+      pass 0 "$FUNCNAME: No GPU XID error found"
       return 0
    fi
 }

--- a/customTests/azure_hw_topology_check.nhc
+++ b/customTests/azure_hw_topology_check.nhc
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source /etc/nhc/scripts/azure_common.nhc
+
 function load_expected_topology() {
     TOPO_FILE="$1"
 
@@ -86,4 +88,6 @@ function check_hw_topology() {
         missing_str=$(IFS=',' ; echo "${formatted_missing[*]}")
         die 1 "$FUNCNAME: Topology mismatch! Expected to find $missing_str" # awkward spacing to get formatting right
     fi
+
+    pass 0 "$FUNCNAME: Topology passed check against $TOPO_FILE"
 }

--- a/customTests/azure_ib_link_flapping.nhc
+++ b/customTests/azure_ib_link_flapping.nhc
@@ -1,4 +1,6 @@
 #!/bin/bash
+
+source /etc/nhc/scripts/azure_common.nhc
   
 #expect to not have any IB link flaps within a given time interval (in hours)
 IB_FLAPPING_LINK_TEST="IB link flapping detected"
@@ -58,6 +60,7 @@ if [ "$lost_carrier_line" != "" ]; then
    fi
 else
    log "No IB link flapping entry in syslog"
+   pass 0 "$FUNCNAME: No IB link flapping found"
    return 0
 fi
 }

--- a/customTests/azure_ib_write_bw_gdr.nhc
+++ b/customTests/azure_ib_write_bw_gdr.nhc
@@ -64,6 +64,7 @@ function run_ib_bw_gdr(){
 	 return 1
   fi
  
+  pass 0 "$FUNCNAME: IB write bandwidth test IB_WRITE_BW passed"
   return 0
 }
 
@@ -90,5 +91,6 @@ function check_ib_bw_gdr(){
 
    remove_clock_boost
 
+   pass 0 "$FUNCNAME: check passed"
    return 0
 }

--- a/customTests/azure_ib_write_bw_non_gdr.nhc
+++ b/customTests/azure_ib_write_bw_non_gdr.nhc
@@ -77,6 +77,7 @@ function ib_write(){
          return 1
    fi
    dbg "ib_write_lb_${device}: $ib_bandwidth Gbps"
+   pass 0 "$FUNCNAME: IB write bandwidth non gdr test passed"
    return 0
 }
 
@@ -96,5 +97,6 @@ function check_ib_bw_non_gdr(){
       ib_write $device $MSG_SIZE $EXP_IB_BW
    done
 
+   pass 0 "$FUNCNAME: check passed"
    return 0
 }

--- a/customTests/azure_nccl_allreduce.nhc
+++ b/customTests/azure_nccl_allreduce.nhc
@@ -67,6 +67,7 @@ function check_nccl_allreduce() {
          dbg "$nccl_allreduce_out"
          dbg "Iteration ${iter} of ${REPEATS} failed: NCCL allreduce bandwidth $avg_bus_bw GB/s < $EXP_NCCL_ALLREDUCE_BW GB/s"
       else
+         pass 0 "$FUNCNAME: NCCL all reduce bandwidth test passed, $avg_bus_bw GB/s"
          return 0
       fi
    done

--- a/customTests/azure_nccl_allreduce_ib_loopback.nhc
+++ b/customTests/azure_nccl_allreduce_ib_loopback.nhc
@@ -57,6 +57,7 @@ function check_nccl_allreduce_ib_loopback() {
          dbg "Iteration ${iter} of ${REPEATS} failed: NCCL allreduce IB loopback bandwidth $avg_bus_bw GB/s < $EXP_NCCL_ALLREDUCE_IB_LOOPBACK_BW GB/s"
       else
          dbg "NCCL allreduce IB loopback bandwidth $avg_bus_bw GB/s"
+         pass 0 "$FUNCNAME: NCCL allreduce IB loopback bandwidth test passed, $avg_bus_bw GB/s"
          return 0
       fi
    done

--- a/customTests/csc_nvidia_smi.nhc
+++ b/customTests/csc_nvidia_smi.nhc
@@ -2,14 +2,18 @@
 
 # Check for GPU ECC errors
 
+source /etc/nhc/scripts/azure_common.nhc
+
 NVIDIA_SMI_HEALTHMON="${NVIDIA_SMI_HEALTHMON:-nvidia-smi}"
 NVIDIA_SMI_HEALTHMON_ARGS="${NVIDIA_SMI_HEALTHMON_ARGS}"
+NVSMI_OUTPUT_VAR="$(nvidia-smi)"
+
 
 NVSMI_HEALTHMON_LINES=( )
 NVSMI_HEALTHMON_OUTPUT=""
 NVSMI_HEALTHMON_RC=""
 
-export NVSMI_HEALTHMON_LINES NVSMI_HEALTHMON_OUTPUT NVSMI_HEALTHMON_RC
+export NVSMI_HEALTHMON_LINES NVSMI_HEALTHMON_OUTPUT NVSMI_HEALTHMON_RC NVSMI_OUTPUT_VAR
 
 function nhc_nvsmi_gather_data() {
     local IFS
@@ -23,12 +27,15 @@ function nhc_nvsmi_gather_data() {
 # Run the nvidia-smi utility and verify that all GPUs
 # are functioning properly.
 function check_nvsmi_healthmon() {
+    dbg "$NVSMI_OUTPUT_VAR"
+
     if [[ -z "$NVSMI_HEALTHMON_RC" ]]; then
         nhc_nvsmi_gather_data
     fi
 
     if [[ $NVSMI_HEALTHMON_RC -eq 0 ]]; then
         dbg "$FUNCNAME:  $NVIDIA_SMI_HEALTHMON completed successfully"
+        pass 0 "$FUNCNAME: $NVIDIA_SMI_HEALTHMON completed successfully"
         return 0
     elif [[ $NVSMI_HEALTHMON_RC -eq 4 ]]; then
         die 1 "$FUNCNAME:  $NVIDIA_SMI_HEALTHMON:  Permission denied"


### PR DESCRIPTION
Added successful test completion to health checks output and log files for each nhc test. In addition to that I have also added the output of nvidia-smi to the health log of the health checks when the -v (verbose) flag is added.