### PR TITLE
Add NCCL Tests to NCv4 and NCv5

### DIFF
--- a/conf/nc48ads_a100_v4.conf
+++ b/conf/nc48ads_a100_v4.conf
@@ -39,3 +39,4 @@
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
  * || check_nvlink_status
+ * || check_nccl_allreduce 193.0 1 16G

--- a/conf/nc80adis_h100_v5.conf
+++ b/conf/nc80adis_h100_v5.conf
@@ -37,3 +37,4 @@
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
  * || check_nvlink_status
+ * || check_nccl_allreduce 208.0 1 16G

--- a/conf/nc96ads_a100_v4.conf
+++ b/conf/nc96ads_a100_v4.conf
@@ -39,4 +39,4 @@
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
  * || check_nvlink_status
- * || check_nccl_allreduce 25 1 $AZ_NHC_ROOT/topofiles/ncv4-topo.xml 8G
+ * || check_nccl_allreduce 25 1 8G $AZ_NHC_ROOT/topofiles/ncv4-topo.xml

--- a/conf/nd40rs_v2.conf
+++ b/conf/nd40rs_v2.conf
@@ -39,7 +39,7 @@
  * || check_gpu_clock_throttling
  * || check_gpu_bw 10
  * || check_nvlink_status
- * || check_nccl_allreduce 110.0 1 $AZ_NHC_ROOT/topofiles/ndv2-topo.xml 8G
+ * || check_nccl_allreduce 110.0 1 8G $AZ_NHC_ROOT/topofiles/ndv2-topo.xml
 
 
 #######################################################################

--- a/conf/nd96amsr_a100_v4.conf
+++ b/conf/nd96amsr_a100_v4.conf
@@ -54,7 +54,7 @@
  * || check_gpu_bw 21 238
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
- * || check_nccl_allreduce 228.0 1 $AZ_NHC_ROOT/topofiles/ndv4-topo.xml 16G
+ * || check_nccl_allreduce 228.0 1 16G $AZ_NHC_ROOT/topofiles/ndv4-topo.xml
  * || check_nvlink_status
 
 
@@ -63,5 +63,5 @@
 ##### Additional IB checks
 #####
 * || check_ib_bw_gdr 180.0
-* || check_nccl_allreduce_ib_loopback 18.0 1 $AZ_NHC_ROOT/topofiles/ndv4-topo.xml 16G
+* || check_nccl_allreduce_ib_loopback 18.0 1 16G $AZ_NHC_ROOT/topofiles/ndv4-topo.xml
 * || check_ib_link_flapping 6

--- a/conf/nd96asr_v4.conf
+++ b/conf/nd96asr_v4.conf
@@ -54,7 +54,7 @@
  * || check_gpu_bw 21 235
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
- * || check_nccl_allreduce 228.0 1 $AZ_NHC_ROOT/topofiles/ndv4-topo.xml 8G
+ * || check_nccl_allreduce 228.0 1 8G $AZ_NHC_ROOT/topofiles/ndv4-topo.xml
  * || check_nvlink_status
 
 
@@ -63,5 +63,5 @@
 #### Additional IB checks
 ####
  * || check_ib_bw_gdr 180.0
- * || check_nccl_allreduce_ib_loopback 18.0 1 $AZ_NHC_ROOT/topofiles/ndv4-topo.xml 8G
+ * || check_nccl_allreduce_ib_loopback 18.0 1 8G $AZ_NHC_ROOT/topofiles/ndv4-topo.xml
  * || check_ib_link_flapping 6

--- a/conf/nd96is_h100_v5.conf
+++ b/conf/nd96is_h100_v5.conf
@@ -29,5 +29,5 @@
  * || check_gpu_bw 48 335
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
- * || check_nccl_allreduce 460.0 1 $AZ_NHC_ROOT/topofiles/ndv5-topo.xml 16G
+ * || check_nccl_allreduce 460.0 1 16G $AZ_NHC_ROOT/topofiles/ndv5-topo.xml
  * || check_nvlink_status

--- a/conf/nd96isr_h100_v5.conf
+++ b/conf/nd96isr_h100_v5.conf
@@ -47,7 +47,7 @@
  * || check_gpu_bw 48 335
  * || check_gpu_ecc 20000000 10000
  * || check_gpu_clock_throttling
- * || check_nccl_allreduce 460.0 1 $AZ_NHC_ROOT/topofiles/ndv5-topo.xml 16G
+ * || check_nccl_allreduce 460.0 1 16G $AZ_NHC_ROOT/topofiles/ndv5-topo.xml
  * || check_nvlink_status
 
 

--- a/customTests/azure_nccl_allreduce.nhc
+++ b/customTests/azure_nccl_allreduce.nhc
@@ -4,8 +4,8 @@ source /etc/nhc/scripts/azure_common.nhc
 
 # Check for NVlink issues by running NCCL allreduce.
 function collect_nccl_allreduce_data() {
-   TOPOFILE=$1
-   MESSAGE_SIZE=$2
+   MESSAGE_SIZE=$1
+   TOPOFILE=$2
    gpu_count=$(nvidia-smi --list-gpus | wc -l)
 
    if [ -z "$gpu_count" ]; then
@@ -34,8 +34,8 @@ function check_nccl_allreduce() {
    EXP_NCCL_ALLREDUCE_BW=$1
    REPEATS="${2:-1}"
 
-   TOPOFILE=$3
-   MESSAGE_SIZE=$4
+   MESSAGE_SIZE=$3
+   TOPOFILE=$4
 
    if ! check_all_reduce_dependencies ; then
       die 1 -e "$FUNCNAME: Missing one or more dependencies. FaultCode: NHCNA"
@@ -44,7 +44,7 @@ function check_nccl_allreduce() {
 
    for iter in $(seq 1 $REPEATS)
    do
-      collect_nccl_allreduce_data $TOPOFILE $MESSAGE_SIZE
+      collect_nccl_allreduce_data $MESSAGE_SIZE $TOPOFILE
 
       for ((i=0; i<${#nccl_allreduce_out_lines[*]}; i++))
       do

--- a/customTests/azure_nccl_allreduce_ib_loopback.nhc
+++ b/customTests/azure_nccl_allreduce_ib_loopback.nhc
@@ -5,8 +5,8 @@ source /etc/nhc/scripts/azure_common.nhc
 # Check for IB issues by running NCCL allreduce disabling NCCL shared memory.
 function collect_nccl_allreduce_ib_loopback_data() {
 
-   TOPOFILE=$1
-   MESSAGE_SIZE=$2
+   MESSAGE_SIZE=$1
+   TOPOFILE=$2
    MPI_ARGS="-np 8 --map-by ppr:8:node -bind-to numa -mca coll_hcoll_enable 0 --allow-run-as-root"
    ENVIRON_VARS="-x LD_LIBRARY_PATH=$LD_LIBRARY_PATH -x NCCL_IB_PCI_RELAXED_ORDERING=1 -x UCX_IB_PCI_RELAXED_ORDERING=on -x UCX_TLS=tcp -x UCX_NET_DEVICES=eth0 -x CUDA_DEVICE_ORDER=PCI_BUS_ID -x NCCL_SOCKET_IFNAME=eth0 -x NCCL_NET_GDR_LEVEL=5 -x NCCL_TOPO_FILE=$TOPOFILE -x NCCL_SHM_DISABLE=1 -x NCCL_P2P_DISABLE=1"
    NCCL_ARGS="-b $MESSAGE_SIZE -f 2 -g 1 -e $MESSAGE_SIZE -c 1"
@@ -29,8 +29,8 @@ function check_nccl_allreduce_ib_loopback() {
    
    EXP_NCCL_ALLREDUCE_IB_LOOPBACK_BW=$1
    REPEATS="${2:-1}"
-   TOPOFILE=$3
-   MESSAGE_SIZE=$4
+   MESSAGE_SIZE=$3
+   TOPOFILE=$4
 
    if ! check_all_reduce_dependencies ; then
       die 1 -e "$FUNCNAME: Missing one or more dependencies. FaultCode: NHCNA"
@@ -39,7 +39,7 @@ function check_nccl_allreduce_ib_loopback() {
 
    for iter in $(seq 1 $REPEATS)
    do
-      collect_nccl_allreduce_ib_loopback_data $TOPOFILE $MESSAGE_SIZE
+      collect_nccl_allreduce_ib_loopback_data $MESSAGE_SIZE $TOPOFILE
 
       for ((i=0; i<${#nccl_allreduce_ib_loopback_out_lines[*]}; i++))
       do


### PR DESCRIPTION
- Add check_all_reduce tests to NC48ads_a100_v4 and NC80adis_h100_v5
- Modify nccl test to have optional topo file argument