### PR TITLE
Fixing the definition for the smaller variants of hbv4 memory test

### DIFF
--- a/conf/hb176-144rs_v4.conf
+++ b/conf/hb176-144rs_v4.conf
@@ -20,7 +20,7 @@
 ### Hardware checks
 ###
  * || check_hw_cpuinfo 2 144 144
- * || check_hw_physmem 792561408kB 726513480kB 3%
+ * || check_hw_physmem 792561408kB 792561408kB 3%
  * || check_hw_swap 0kB 0kB 3%
  * || check_hw_ib 400 mlx5_ib0:1
  * || check_hw_eth lo

--- a/conf/hb176-24rs_v4.conf
+++ b/conf/hb176-24rs_v4.conf
@@ -20,7 +20,7 @@
 ### Hardware checks
 ###
  * || check_hw_cpuinfo 2 24 24
- * || check_hw_physmem 792561408kB 726513480kB 3%
+ * || check_hw_physmem 792561408kB 792561408kB 3%
  * || check_hw_swap 0kB 0kB 3%
  * || check_hw_ib 400 mlx5_ib0:1
  * || check_hw_eth lo

--- a/conf/hb176-48rs_v4.conf
+++ b/conf/hb176-48rs_v4.conf
@@ -20,7 +20,7 @@
 ### Hardware checks
 ###
  * || check_hw_cpuinfo 2 48 48
- * || check_hw_physmem 792561408kB 726513480kB 3%
+ * || check_hw_physmem 792561408kB 792561408kB 3%
  * || check_hw_swap 0kB 0kB 3%
  * || check_hw_ib 400 mlx5_ib0:1
  * || check_hw_eth lo


### PR DESCRIPTION
For the undersubbed variants of HBv4, i.e. 144rs, 24rs, and 48 rs, the definitions are wrong for the check memory test. The order of input is `min max threshold` and it is defined with a max that is smaller than the min. Most likely a copy and paste mistake from the "bad tests" section.