### PR TITLE
Remove NHC2006 since it's the same as NHC2020 and unused

### DIFF
--- a/triggerGHR/config/nhc_fault_dictionary.cfg
+++ b/triggerGHR/config/nhc_fault_dictionary.cfg
@@ -3,7 +3,6 @@ NHC2002 = Resource.Hpc.Unhealthy.MissingIB  #Use this to report an HPC node with
 NHC2003 = Resource.Hpc.Unhealthy.IBPerformance  #Use this to report an HPC node with degraded IB performance
 NHC2004 = Resource.Hpc.Unhealthy.IBPortDown #Use this to report when IB port is persistently down
 NHC2005 = Resource.Hpc.Unhealthy.IBPortFlapping #Use this to report when IB port is flapping
-NHC2006 = Resource.Hpc.Unhealthy.HpcGpuDcgmDiagFailure #Use this to report an HPC node with GPU DCGMI diagnostic failure.
 NHC2007 = Resource.Hpc.Unhealthy.HpcRowRemapFailure #Use this to report an HPC node with GPU row remap failure.
 NHC2008 = Resource.Hpc.Unhealthy.HpcInforomCorruption #se this to report an HPC node with GPU infoROM corruption.
 NHC2009 = Resource.Hpc.Unhealthy.HpcMissingGpu #Use this to report an HPC node with missing GPUs


### PR DESCRIPTION
Removing unused error code that is the same as another one (`NHC2020`)