### PR TITLE
[Small fix, 1 line] Update azure_gpu_nvlink.nhc: call `pass` correctly

### DIFF
--- a/customTests/azure_gpu_nvlink.nhc
+++ b/customTests/azure_gpu_nvlink.nhc
@@ -36,7 +36,7 @@ function check_nvlink_status(){
             die 1 "$FUNCNAME: GPU $gpu_id has nvlinks inactive: $inactive_links. FaultCode: NHC2016"
             return 1
         else
-            pass "$FUNCNAME: GPU $gpu_id has all nvlinks active."
+            pass 0 "$FUNCNAME: GPU $gpu_id has all nvlinks active."
         fi
     done
     


### PR DESCRIPTION
In #132 the output function for success had been changed and is missing the return code argument.

What happens currently the message is parsed as return code and `shift` away in the `pass` function, leaving no message to display.

Currently the output looks like this:
```
SUCCESS:  nhc:  Health check passed:  check_gpu_ecc: ECC checks passed
SUCCESS:  nhc:  Health check passed:  
SUCCESS:  nhc:  Health check passed:  
SUCCESS:  nhc:  Health check passed:  
SUCCESS:  nhc:  Health check passed:  
SUCCESS:  nhc:  Health check passed:  
SUCCESS:  nhc:  Health check passed:  
SUCCESS:  nhc:  Health check passed:  
SUCCESS:  nhc:  Health check passed:  
```

- The `pass` function called: https://github.com/Azure/azurehpc-health-checks/blob/a0af80449ecd0bf39363ce19c56cdecb0b5b297e/customTests/azure_common.nhc#L6-L34

- Example for successful call https://github.com/Azure/azurehpc-health-checks/blob/a0af80449ecd0bf39363ce19c56cdecb0b5b297e/customTests/azure_gpu_ecc.nhc#L153

If argument is given, script gives expected output

```
SUCCESS:  nhc:  Health check passed:  check_gpu_ecc: ECC checks passed
SUCCESS:  nhc:  Health check passed:  check_nvlink_status: GPU 0 has all nvlinks active.
SUCCESS:  nhc:  Health check passed:  check_nvlink_status: GPU 1 has all nvlinks active.
SUCCESS:  nhc:  Health check passed:  check_nvlink_status: GPU 2 has all nvlinks active.
SUCCESS:  nhc:  Health check passed:  check_nvlink_status: GPU 3 has all nvlinks active.
SUCCESS:  nhc:  Health check passed:  check_nvlink_status: GPU 4 has all nvlinks active.
SUCCESS:  nhc:  Health check passed:  check_nvlink_status: GPU 5 has all nvlinks active.
SUCCESS:  nhc:  Health check passed:  check_nvlink_status: GPU 6 has all nvlinks active.
SUCCESS:  nhc:  Health check passed:  check_nvlink_status: GPU 7 has all nvlinks active.
```