### PR TITLE
Missing arg for pass in check_nvlink_status

### DIFF
--- a/customTests/azure_gpu_nvlink.nhc
+++ b/customTests/azure_gpu_nvlink.nhc
@@ -36,7 +36,7 @@ function check_nvlink_status(){
             die 1 "$FUNCNAME: GPU $gpu_id has nvlinks inactive: $inactive_links. FaultCode: NHC2016"
             return 1
         else
-            pass "$FUNCNAME: GPU $gpu_id has all nvlinks active."
+            pass 0 "$FUNCNAME: GPU $gpu_id has all nvlinks active."
         fi
     done
     


### PR DESCRIPTION
No message was output on success.