### PR TITLE
Add aarch64/Grace NVIDIA image support

### DIFF
--- a/customTests/azure_gpu_bandwidth.nhc
+++ b/customTests/azure_gpu_bandwidth.nhc
@@ -177,6 +177,7 @@ function save_nvbandwidth_matrix(){
     return 0
 }
 
+# Usage: parse_nvbandwidth_results "$nvbandwidth_output" 2 "$H2D" "$D2H" "$P2P"
 function parse_nvbandwidth_results(){
     local nvresult=$1
     local gpu_count=$2

--- a/customTests/azure_gpu_bandwidth.nhc
+++ b/customTests/azure_gpu_bandwidth.nhc
@@ -121,6 +121,120 @@ function evaluate_nvBW_result(){
     return 0
 }
 
+function save_nvbandwidth_matrix(){
+    local test_name=$1
+    local matrix_lines=$2
+    local matrix_line_count=$3
+    local gpu_count=$4
+    local expected_data_rows
+    local row_index
+    local column_index
+    local -a matrix_rows
+    local -a fields
+
+    if [[ -z "$test_name" ]]; then
+        return 0
+    fi
+
+    case "$test_name" in
+        "$H2D"|"$D2H")
+            expected_data_rows=1
+            ;;
+        "$P2P")
+            expected_data_rows=$gpu_count
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+
+    if (( matrix_line_count != expected_data_rows + 1 )); then
+        return 1
+    fi
+
+    readarray -t matrix_rows < <(printf '%s' "$matrix_lines")
+    read -ra fields <<< "${matrix_rows[0]}"
+    if (( ${#fields[@]} != gpu_count )); then
+        return 1
+    fi
+    for ((column_index=0; column_index<gpu_count; column_index++)); do
+        if [[ "${fields[$column_index]}" != "$column_index" ]]; then
+            return 1
+        fi
+    done
+
+    for ((row_index=1; row_index<${#matrix_rows[@]}; row_index++)); do
+        read -ra fields <<< "${matrix_rows[$row_index]}"
+        if (( ${#fields[@]} != gpu_count + 1 )); then
+            return 1
+        fi
+        if [[ "${fields[0]}" != "$((row_index - 1))" ]]; then
+            return 1
+        fi
+    done
+
+    result_lines_array["$test_name"]="$(printf '%s\n' "${matrix_rows[@]:1}")"
+    return 0
+}
+
+function parse_nvbandwidth_results(){
+    local nvresult=$1
+    local gpu_count=$2
+    shift 2
+    local -a expected_tests=( "$@" )
+    local current_test=""
+    local matrix_lines=""
+    local matrix_line_count=0
+    local reading_matrix=false
+    local matrix_row_regex='^[[:space:]]*[0-9]+([[:space:]]+(N/A|[0-9]+([.][0-9]+)?([eE][+-]?[0-9]+)?))+[[:space:]]*$'
+    local expected_test
+    local line
+
+    if (( gpu_count <= 0 || ${#expected_tests[@]} == 0 )); then
+        return 1
+    fi
+
+    result_lines_array=()
+
+    while IFS= read -r line; do
+        if [[ "$line" == Running* ]]; then
+            if ! save_nvbandwidth_matrix "$current_test" "$matrix_lines" "$matrix_line_count" "$gpu_count"; then
+                return 1
+            fi
+
+            current_test="${line#Running}"
+            current_test="${current_test//./}"
+            current_test="${current_test#"${current_test%%[![:space:]]*}"}"
+            matrix_lines=""
+            matrix_line_count=0
+            reading_matrix=false
+            continue
+        fi
+
+        if [[ "$line" == *"memcpy"* ]]; then
+            reading_matrix=true
+            continue
+        fi
+
+        if [[ "$reading_matrix" == true ]] && [[ "$line" =~ $matrix_row_regex ]]; then
+            matrix_lines+="$line"$'\n'
+            matrix_line_count=$((matrix_line_count + 1))
+        elif [[ "$reading_matrix" == true ]] && (( matrix_line_count > 0 )); then
+            reading_matrix=false
+        fi
+    done <<< "$nvresult"
+
+    if ! save_nvbandwidth_matrix "$current_test" "$matrix_lines" "$matrix_line_count" "$gpu_count"; then
+        return 1
+    fi
+
+    for expected_test in "${expected_tests[@]}"; do
+        if [[ -z "${result_lines_array[$expected_test]+present}" ]]; then
+            return 1
+        fi
+    done
+}
+
 function check_nvBW_gpu_bw()
 {
     # Check GPU BW using NVBandwidth
@@ -156,34 +270,9 @@ function check_nvBW_gpu_bw()
     if ! catch_error "$cmd" "$error_nbw"; then
         return 0
     fi
-    nvresult=$output
-    IFS=$'\n'
-    nvout=( $nvresult )
-    IFS=$' \t\n'
-
-    current_test=""
-
-    # Extract the lines for each test
-    for line in "${nvout[@]}"; do
-        if [[ $line == Running* ]]; then
-            if [ "$current_test" != "" ]; then
-                extracted_lines="$(echo "${extracted_lines}" | awk 'NR>1')"
-                result_lines_array["$current_test"]="$extracted_lines"
-            fi
-            # Set current test and remove extra spaces and dots
-            current_test="${line#Running}" && current_test="${current_test//./}" && current_test="${current_test#"${current_test%%[![:space:]]*}"}"
-            extracted_lines=""
-        fi
-
-        if [[ ! "$line" == *"memcpy"*  ]]; then
-            extracted_lines+="$line"$'\n'
-        fi
-    done
-    
-    # Save the last test's extracted lines
-    if [ "$current_test" != "" ]; then
-        extracted_lines="$(echo "${extracted_lines}" | awk 'NR>1')"
-        result_lines_array["$current_test"]="$extracted_lines"
+    if ! parse_nvbandwidth_results "$output" "$ngpus" $cmd_args; then
+        die 1 "check_gpu_bw: failed to parse NVBandwidth results. FaultCode: NHCNA"
+        return 0
     fi
 
     evaluate_nvBW_result $EXP_GPU_PCIE_BW $EXP_P2P_BW

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -1,6 +1,8 @@
 # Az NHC Developer Guide #
 
-Az NHC is ran inside an Ubuntu 22.04 docker container. See instructions for how to address changes in the docker image.
+Az NHC runs inside a Docker container. Container dependencies vary by image
+and are independent of the host operating system. See the instructions below
+when changing a Docker image.
 
 ## Pre-requisites ##
 
@@ -18,7 +20,7 @@ Az NHC is ran inside an Ubuntu 22.04 docker container. See instructions for how 
 
     Any changes to how the ```docker run``` command is ran needs to be updated in [Docker docs](./dockerfile/README.MD) and any additional instructions in the main [docs](./README.md).
 
-    Grace-based (aarch64) SKUs use a separate image built from [azure-nvrt-nhc-aarch64.dockerfile](./dockerfile/azure-nvrt-nhc-aarch64.dockerfile), tagged `mcr.microsoft.com/aznhc/aznhc-nv:aarch64`. `run-health-checks.sh` selects it automatically based on `uname -m`. When changing NVIDIA/IB tooling, check whether the aarch64 dockerfile needs the same update (it uses a different apt repo, DOCA-Host, instead of MLNX_OFED, since no aarch64 MOFED build exists) — see that dockerfile's header comment for details.
+    Grace-based (aarch64) SKUs use a separate image built from [azure-nvrt-nhc-aarch64.dockerfile](./dockerfile/azure-nvrt-nhc-aarch64.dockerfile), tagged `mcr.microsoft.com/aznhc/aznhc-nv:aarch64`. Its container uses Ubuntu 24.04, CUDA 13, and DOCA-Host packages. `run-health-checks.sh` selects it automatically based on `uname -m`. When changing NVIDIA or IB tooling, check whether the aarch64 image needs the same update.
 
 2. Launching the docker container as an interactive session may be easier to develop on:
 

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -18,6 +18,8 @@ Az NHC is ran inside an Ubuntu 22.04 docker container. See instructions for how 
 
     Any changes to how the ```docker run``` command is ran needs to be updated in [Docker docs](./dockerfile/README.MD) and any additional instructions in the main [docs](./README.md).
 
+    Grace-based (aarch64) SKUs use a separate image built from [azure-nvrt-nhc-aarch64.dockerfile](./dockerfile/azure-nvrt-nhc-aarch64.dockerfile), tagged `mcr.microsoft.com/aznhc/aznhc-nv:aarch64`. `run-health-checks.sh` selects it automatically based on `uname -m`. When changing NVIDIA/IB tooling, check whether the aarch64 dockerfile needs the same update (it uses a different apt repo, DOCA-Host, instead of MLNX_OFED, since no aarch64 MOFED build exists) — see that dockerfile's header comment for details.
+
 2. Launching the docker container as an interactive session may be easier to develop on:
 
   ```bash

--- a/dockerfile/README.MD
+++ b/dockerfile/README.MD
@@ -2,7 +2,9 @@
 
 ## OverView ##
 
-Azure NHC is run within an Ubuntu 22.04 docker container with either Nvidia or AMD runtime enabled.
+Azure NHC runs in Docker containers with either the Nvidia or AMD runtime
+enabled. Container dependencies vary by image and are independent of the host
+operating system.
 
 There are two ways of running Az NHC, with the provided run script and also as a stand alone container.
 
@@ -27,7 +29,7 @@ Notes:
 
 ### aarch64 / Grace (GB200, GB300, ...) SKUs ###
 
-Grace-based Nvidia SKUs use a separate arm64-native image, tagged `mcr.microsoft.com/aznhc/aznhc-nv:aarch64`. It is built from the [aarch64 CUDA Dockerfile](./azure-nvrt-nhc-aarch64.dockerfile), which documents in its header comment how it differs from the x86_64 image (CUDA 13 base for Blackwell support, DOCA-Host apt repo instead of MLNX_OFED, no STREAM binary).
+Grace-based Nvidia SKUs use a separate arm64-native image, tagged `mcr.microsoft.com/aznhc/aznhc-nv:aarch64`. It is built from the [aarch64 CUDA Dockerfile](./azure-nvrt-nhc-aarch64.dockerfile) using Ubuntu 24.04, CUDA 13, and DOCA-Host packages. STREAM is not currently included in this image.
 
 - `run-health-checks.sh` auto-selects this image whenever it detects `uname -m == aarch64`, so no extra flags are needed on Grace hosts.
 - Pull it explicitly with: ```sudo ./pull-image-mcr.sh cuda-arm```

--- a/dockerfile/README.MD
+++ b/dockerfile/README.MD
@@ -25,6 +25,15 @@ Notes:
 - To view the latest Nvidia/CUDA image current software versions take a look at the [CUDA Dockerfile](./azure-nvrt-nhc.dockerfile)
 - To view the latest AMD/ROCm image current software versions take a look at the [ROCm Dockerfile](./azure-rocm-nhc.dockerfile)
 
+### aarch64 / Grace (GB200, GB300, ...) SKUs ###
+
+Grace-based Nvidia SKUs use a separate arm64-native image, tagged `mcr.microsoft.com/aznhc/aznhc-nv:aarch64`. It is built from the [aarch64 CUDA Dockerfile](./azure-nvrt-nhc-aarch64.dockerfile), which documents in its header comment how it differs from the x86_64 image (CUDA 13 base for Blackwell support, DOCA-Host apt repo instead of MLNX_OFED, no STREAM binary).
+
+- `run-health-checks.sh` auto-selects this image whenever it detects `uname -m == aarch64`, so no extra flags are needed on Grace hosts.
+- Pull it explicitly with: ```sudo ./pull-image-mcr.sh cuda-arm```
+- Build it locally with: ```sudo ./build_image.sh cuda-arm``` (must be run on an aarch64 host with Docker's arm64 default platform)
+- GPUDirect RDMA (`check_ib_bw_gdr`) requires the `nvidia_peermem` kernel module to be loaded on the **host** (`sudo modprobe nvidia-peermem`). If it isn't loaded, GDR IB tests fail with `Couldn't allocate MR with error=14`, which can look like a hardware fault but is a missing host module.
+
 ## Run Modes ##
 
 ### Prefered Method: Run Script ###

--- a/dockerfile/azure-nvrt-nhc-aarch64.dockerfile
+++ b/dockerfile/azure-nvrt-nhc-aarch64.dockerfile
@@ -1,0 +1,187 @@
+# aarch64 (Grace/Blackwell) variant of azure-nvrt-nhc.dockerfile
+
+################################################################################
+# STAGE 1: Builder — compile all tools using the full CUDA devel image
+################################################################################
+FROM nvcr.io/nvidia/cuda:13.0.0-cudnn-devel-ubuntu24.04 AS builder
+
+SHELL ["/bin/bash", "-c"]
+
+# Semicolon-separated list of supported GPU compute capabilities, shared by
+# nccl-tests' NVCC_GENCODE and nvbandwidth's CMAKE_CUDA_ARCHITECTURES.
+# 90 = H100/H200 (compat), 100 = B200/GB200, 103 = GB300.
+ARG CUDA_ARCH_LIST="90;100;103"
+
+ENV DOCA_VERSION=3.3.0
+ENV NHC_VERSION=1.4.3
+ENV NV_BANDWIDTH_VERSION=0.10.0
+ENV OPEN_MPI_VERSION=5.0.5
+ENV NCCL_TEST_VERSION=2.13.8
+
+ENV AZ_NHC_ROOT="/azure-nhc"
+ENV MPI_HOME=/opt/openmpi
+
+WORKDIR /tmp
+
+RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends          \
+    git wget curl ca-certificates gnupg                 \
+    cmake build-essential                               \
+    libpci-dev libboost-program-options-dev             \
+    libssl-dev devscripts bats                          \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add the DOCA-Host public apt repo. Provides rdma-core/perftest/ucx at
+# versions matching Azure's Grace host images.
+RUN wget -qO - https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub | \
+    gpg --dearmor -o /usr/share/keyrings/doca-mellanox.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/doca-mellanox.gpg] https://linux.mellanox.com/public/repo/doca/${DOCA_VERSION}/ubuntu24.04/arm64-sbsa/ ./" \
+    > /etc/apt/sources.list.d/doca.list && \
+    apt-get update -y
+
+# Install IB user-space needed to compile OpenMPI/perftest with verbs support,
+# plus the prebuilt perftest binary itself (has GDR/--use_cuda support already).
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    rdma-core ibverbs-providers libibverbs-dev librdmacm-dev libibumad-dev    \
+    infiniband-diags perftest ucx                                             \
+    && mkdir -p ${AZ_NHC_ROOT}/bin ${AZ_NHC_ROOT}/LICENSES                    \
+    && cp "$(command -v ib_write_bw)" ${AZ_NHC_ROOT}/bin/ib_write_bw          \
+    && cp "$(command -v ib_write_bw)" ${AZ_NHC_ROOT}/bin/ib_write_bw_nongdr   \
+    && (dpkg -L perftest | grep -i copyright | head -1 | xargs -I{} cp {} ${AZ_NHC_ROOT}/LICENSES/perftest_LICENSE || true) \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build OpenMPI with explicit --with-verbs/--with-rdmacm
+# pointed at the DOCA-provided headers/libs installed above.
+RUN cd /tmp && \
+    wget -q "https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-${OPEN_MPI_VERSION}.tar.gz" && \
+    tar -xf openmpi-${OPEN_MPI_VERSION}.tar.gz && \
+    cd openmpi-${OPEN_MPI_VERSION} && \
+    mkdir -p ${AZ_NHC_ROOT}/LICENSES && \
+    cp LICENSE ${AZ_NHC_ROOT}/LICENSES/OpenMPI_LICENSE.txt && \
+    ./configure --prefix=/opt/openmpi --enable-mpirun-prefix-by-default \
+        --with-verbs --with-rdmacm && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/openmpi-${OPEN_MPI_VERSION}*
+
+# Save the NCCL license (libnccl2/libnccl-dev come preinstalled in the
+# cudnn-devel base image at a version matching CUDA 13.0 arm64)
+RUN cp /usr/share/doc/libnccl2/copyright ${AZ_NHC_ROOT}/LICENSES/nccl_LICENSE.txt || true
+
+# Build NCCL-Tests. nccl-tests' default NVCC_GENCODE targets legacy archs
+# (compute_35/50/60/61/70/80) that CUDA 13's nvcc no longer accepts
+# ("Unsupported gpu architecture 'compute_60'"); override it using
+# CUDA_ARCH_LIST (see top of file) instead of hardcoding archs here.
+RUN cd /tmp && \
+    wget -q -O - https://github.com/NVIDIA/nccl-tests/archive/refs/tags/v${NCCL_TEST_VERSION}.tar.gz | tar -xz && \
+    cd nccl-tests-${NCCL_TEST_VERSION} && \
+    NVCC_GENCODE="" && \
+    for arch in ${CUDA_ARCH_LIST//;/ }; do \
+        NVCC_GENCODE="${NVCC_GENCODE} -gencode=arch=compute_${arch},code=sm_${arch}"; \
+    done && \
+    last_arch="${CUDA_ARCH_LIST##*;}" && \
+    NVCC_GENCODE="${NVCC_GENCODE} -gencode=arch=compute_${last_arch},code=compute_${last_arch}" && \
+    make MPI=1 MPI_HOME=${MPI_HOME} CUDA_HOME=/usr/local/cuda \
+        NVCC_GENCODE="${NVCC_GENCODE}" && \
+    mkdir -p /opt/nccl-tests/build && \
+    cp -r build/* /opt/nccl-tests/build/ && \
+    rm -rf /tmp/nccl-tests-${NCCL_TEST_VERSION}
+
+# Build NHC
+RUN cd /tmp && \
+    wget -O nhc-${NHC_VERSION}.tar.xz https://github.com/mej/nhc/releases/download/${NHC_VERSION}/lbnl-nhc-${NHC_VERSION}.tar.xz && \
+    tar -xf nhc-${NHC_VERSION}.tar.xz && \
+    rm -f nhc-${NHC_VERSION}.tar.xz && \
+    cd lbnl-nhc-${NHC_VERSION} && \
+    ./configure --prefix=/usr --sysconfdir=/etc --libexecdir=/usr/libexec && \
+    make test && \
+    make install && \
+    mkdir -p ${AZ_NHC_ROOT} && \
+    mv /tmp/lbnl-nhc-${NHC_VERSION}* ${AZ_NHC_ROOT}
+
+# Build nvbandwidth (bumped to v0.10.0 for Blackwell; CMAKE_CUDA_ARCHITECTURES
+# derived from CUDA_ARCH_LIST, see top of file)
+RUN cd /tmp && \
+    wget -q -O - https://github.com/NVIDIA/nvbandwidth/archive/refs/tags/v${NV_BANDWIDTH_VERSION}.tar.gz | tar -xz && \
+    cd nvbandwidth-${NV_BANDWIDTH_VERSION} && \
+    cmake -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCH_LIST}" . && \
+    make && \
+    cp nvbandwidth ${AZ_NHC_ROOT}/bin/ && \
+    cp LICENSE ${AZ_NHC_ROOT}/LICENSES/nvbandwidth_LICENSE && \
+    rm -rf /tmp/nvbandwidth-${NV_BANDWIDTH_VERSION}
+
+# Get Topofiles from AI/HPC images
+RUN mkdir -p ${AZ_NHC_ROOT}/topofiles && \
+    git clone --depth=1 https://github.com/Azure/azhpc-images.git /tmp/azhpc-images && \
+    cp /tmp/azhpc-images/topology/* ${AZ_NHC_ROOT}/topofiles && \
+    rm -rf /tmp/azhpc-images
+
+
+################################################################################
+# STAGE 2: Runtime — slim image with only what's needed to run health checks
+################################################################################
+FROM nvcr.io/nvidia/cuda:13.0.0-runtime-ubuntu24.04
+
+LABEL maintainer="azurehpc-health-checks"
+
+SHELL ["/bin/bash", "-c"]
+
+ENV DOCA_VERSION=3.3.0
+
+ENV AZ_NHC_ROOT="/azure-nhc"
+ENV MPI_BIN=/opt/openmpi/bin
+ENV MPI_INCLUDE=/opt/openmpi/include
+ENV MPI_LIB=/opt/openmpi/lib
+ENV MPI_MAN=/opt/openmpi/share/man
+ENV MPI_HOME=/opt/openmpi
+ENV PATH="${MPI_BIN}:${PATH}"
+
+WORKDIR ${AZ_NHC_ROOT}
+
+# Install runtime-only system packages
+RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends          \
+    --allow-change-held-packages                        \
+    numactl curl sudo systemd wget perl gnupg           \
+    libgomp1 libcap2-bin hwloc                          \
+    openssh-client net-tools bc                         \
+    pciutils                                            \
+    libnccl2                                            \
+    bats                                                \
+    && apt-get upgrade -y --allow-change-held-packages  \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install IB user-space runtime libraries from the DOCA-Host public apt repo
+# (aarch64 replacement for the x86 MLNX_OFED tarball install)
+RUN wget -qO - https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub | \
+    gpg --dearmor -o /usr/share/keyrings/doca-mellanox.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/doca-mellanox.gpg] https://linux.mellanox.com/public/repo/doca/${DOCA_VERSION}/ubuntu24.04/arm64-sbsa/ ./" \
+    > /etc/apt/sources.list.d/doca.list && \
+    apt-get update -y && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    rdma-core ibverbs-providers libibverbs1 librdmacm1 libibumad3 infiniband-diags ucx \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy compiled artifacts from builder
+COPY --from=builder /opt/openmpi          /opt/openmpi
+COPY --from=builder /opt/nccl-tests       /opt/nccl-tests
+COPY --from=builder /azure-nhc            /azure-nhc
+COPY --from=builder /usr/sbin/nhc         /usr/sbin/nhc
+COPY --from=builder /usr/sbin/nhc-genconf /usr/sbin/nhc-genconf
+COPY --from=builder /usr/sbin/nhc-wrapper /usr/sbin/nhc-wrapper
+COPY --from=builder /etc/nhc              /etc/nhc
+COPY --from=builder /usr/libexec/nhc      /usr/libexec/nhc
+
+# Register copied libs with ldconfig
+RUN printf "/opt/openmpi/lib\n/azure-nhc/lib\n" > /etc/ld.so.conf.d/openmpi.conf && ldconfig
+
+# Create workspace directories
+RUN mkdir -p ${AZ_NHC_ROOT}/conf   \
+             ${AZ_NHC_ROOT}/output
+
+# Copy host context files (custom tests, configs, entrypoint)
+COPY LICENSE ${AZ_NHC_ROOT}/LICENSES/azure-nhc_LICENSE.txt
+COPY README.md ${AZ_NHC_ROOT}/README.md
+COPY customTests/*.nhc /etc/nhc/scripts/
+COPY conf ${AZ_NHC_ROOT}/default/conf
+COPY dockerfile/aznhc-entrypoint.sh ${AZ_NHC_ROOT}
+RUN chmod +x ${AZ_NHC_ROOT}/aznhc-entrypoint.sh

--- a/dockerfile/azure-nvrt-nhc-aarch64.dockerfile
+++ b/dockerfile/azure-nvrt-nhc-aarch64.dockerfile
@@ -1,4 +1,4 @@
-# aarch64 (Grace/Blackwell) variant of azure-nvrt-nhc.dockerfile
+# aarch64 (Grace/Blackwell) variant of azure-nvrt-nhc.dockerfile.
 
 ################################################################################
 # STAGE 1: Builder — compile all tools using the full CUDA devel image
@@ -99,8 +99,7 @@ RUN cd /tmp && \
     mkdir -p ${AZ_NHC_ROOT} && \
     mv /tmp/lbnl-nhc-${NHC_VERSION}* ${AZ_NHC_ROOT}
 
-# Build nvbandwidth (bumped to v0.10.0 for Blackwell; CMAKE_CUDA_ARCHITECTURES
-# derived from CUDA_ARCH_LIST, see top of file)
+# Build nvbandwidth for the configured CUDA architectures
 RUN cd /tmp && \
     wget -q -O - https://github.com/NVIDIA/nvbandwidth/archive/refs/tags/v${NV_BANDWIDTH_VERSION}.tar.gz | tar -xz && \
     cd nvbandwidth-${NV_BANDWIDTH_VERSION} && \
@@ -152,7 +151,6 @@ RUN apt-get update -y && DEBIAN_FRONTEND=noninteractive \
     && rm -rf /var/lib/apt/lists/*
 
 # Install IB user-space runtime libraries from the DOCA-Host public apt repo
-# (aarch64 replacement for the x86 MLNX_OFED tarball install)
 RUN wget -qO - https://linux.mellanox.com/public/repo/doca/GPG-KEY-Mellanox.pub | \
     gpg --dearmor -o /usr/share/keyrings/doca-mellanox.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/doca-mellanox.gpg] https://linux.mellanox.com/public/repo/doca/${DOCA_VERSION}/ubuntu24.04/arm64-sbsa/ ./" \

--- a/dockerfile/build_image.sh
+++ b/dockerfile/build_image.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
-# For NHC developers, this script is used to build the cuda or rocm runtime image for NHC
-# The NVIDIA (cuda) Dockerfile uses a multi-stage build — all compilation happens inside
+# For NHC developers, this script is used to build the cuda, cuda-arm, or rocm runtime image for NHC
+# The NVIDIA (cuda/cuda-arm) Dockerfiles use a multi-stage build — all compilation happens inside
 # the container, so no host-side CUDA toolkit or HPC-X is required for cuda builds.
 
-# Choices are: cuda or rocm Runtime
+# Choices are: cuda, cuda-arm, or rocm Runtime
 build_type=$1
+
+# On an aarch64 host, default a plain "cuda" request to "cuda-arm" for convenience
+if [[ -z "$build_type" || "$build_type" == "cuda" ]] && [[ "$(uname -m)" == "aarch64" ]]; then
+    echo "aarch64 host detected, defaulting to cuda-arm build"
+    build_type="cuda-arm"
+fi
 
 script_path="$(realpath "$0")"
 parent_dir="$(dirname "$script_path")"
@@ -17,12 +23,16 @@ if [[ "$build_type" == "cuda" ]]; then
     echo "Nvidia runtime selected (multi-stage build, no host compilation needed)"
     IMAGE="mcr.microsoft.com/aznhc/aznhc-nv"
     DOCK_FILE=dockerfile/azure-nvrt-nhc.dockerfile
+elif [[ "$build_type" == "cuda-arm" ]]; then
+    echo "Nvidia aarch64 (Grace/Blackwell) runtime selected (multi-stage build, no host compilation needed)"
+    IMAGE="mcr.microsoft.com/aznhc/aznhc-nv:aarch64"
+    DOCK_FILE=dockerfile/azure-nvrt-nhc-aarch64.dockerfile
 elif [[ "$build_type" == "rocm" ]]; then
     echo "AMD runtime selected"
     IMAGE="mcr.microsoft.com/aznhc/aznhc-rocm"
     DOCK_FILE=dockerfile/azure-rocm-nhc.dockerfile
 else
-    echo "Please specify a build type: cuda or rocm"
+    echo "Please specify a build type: cuda, cuda-arm, or rocm"
     exit 1
 fi
 

--- a/dockerfile/pull-image-mcr.sh
+++ b/dockerfile/pull-image-mcr.sh
@@ -1,18 +1,24 @@
 #!/bin/bash
 
-# Choices are: cuda or rocm Runtime
+# Choices are: cuda, cuda-arm, or rocm Runtime
 build_type=$1
 
 if [[ -z "$build_type" ]]; then
-    build_type="cuda"
+    if [[ "$(uname -m)" == "aarch64" ]]; then
+        build_type="cuda-arm"
+    else
+        build_type="cuda"
+    fi
 fi
 
 if [[ "$build_type" == "cuda" ]]; then
     DOCK_IMG_NAME="mcr.microsoft.com/aznhc/aznhc-nv"
+elif [[ "$build_type" == "cuda-arm" ]]; then
+    DOCK_IMG_NAME="mcr.microsoft.com/aznhc/aznhc-nv:aarch64"
 elif [[ "$build_type" == "rocm" ]]; then
     DOCK_IMG_NAME="mcr.microsoft.com/aznhc/aznhc-rocm"
 else
-    echo "Please specify a build type: cuda or rocm"
+    echo "Please specify a build type: cuda, cuda-arm, or rocm"
     exit 1
 fi
 

--- a/run-health-checks.sh
+++ b/run-health-checks.sh
@@ -216,21 +216,33 @@ fi
 
 echo "Running health checks using $CONF_FILE and outputting to $OUTPUT_PATH"
 
+CPU_ARCH=$(uname -m)
+case "$CPU_ARCH" in
+    x86_64)
+        DOCK_IMG_NAME_NV_ARCH=$DOCK_IMG_NAME_NV
+        DOCK_IMG_NAME_CPU_ARCH=$DOCK_IMG_NAME_CPU
+        ;;
+    aarch64)
+        DOCK_IMG_NAME_NV_ARCH=$DOCK_IMG_NAME_NV_ARM
+        DOCK_IMG_NAME_CPU_ARCH=$DOCK_IMG_NAME_NV_ARM
+        ;;
+    *)
+        echo "Unsupported CPU architecture: $CPU_ARCH" >&2
+        exit 1
+        ;;
+esac
+
 if lspci | grep -iq NVIDIA ; then
     NVIDIA_RT="--gpus all"
-    if [ "$(uname -m)" == "aarch64" ]; then
-        DOCK_IMG_NAME=$DOCK_IMG_NAME_NV_ARM
-    else
-        DOCK_IMG_NAME=$DOCK_IMG_NAME_NV
-    fi
+    DOCK_IMG_NAME=$DOCK_IMG_NAME_NV_ARCH
 elif lspci | grep -iq AMD ; then
+    if [[ "$CPU_ARCH" != "x86_64" ]]; then
+        echo "Unsupported CPU architecture for AMD GPUs: $CPU_ARCH" >&2
+        exit 1
+    fi
     DOCK_IMG_NAME=$DOCK_IMG_NAME_AMD
 else
-    if [ "$(uname -m)" == "aarch64" ]; then
-        DOCK_IMG_NAME=$DOCK_IMG_NAME_NV_ARM
-    else
-        DOCK_IMG_NAME=$DOCK_IMG_NAME_CPU
-    fi
+    DOCK_IMG_NAME=$DOCK_IMG_NAME_CPU_ARCH
 fi
 
 WORKING_DIR="/azure-nhc"

--- a/run-health-checks.sh
+++ b/run-health-checks.sh
@@ -2,6 +2,7 @@
 
 AZ_NHC_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOCK_IMG_NAME_NV="mcr.microsoft.com/aznhc/aznhc-nv"
+DOCK_IMG_NAME_NV_ARM="mcr.microsoft.com/aznhc/aznhc-nv:aarch64"
 DOCK_IMG_NAME_CPU=$DOCK_IMG_NAME_NV # Default to the NV image
 DOCK_IMG_NAME_AMD="mcr.microsoft.com/aznhc/aznhc-rocm"
 DOCK_CONT_NAME=aznhc
@@ -217,11 +218,19 @@ echo "Running health checks using $CONF_FILE and outputting to $OUTPUT_PATH"
 
 if lspci | grep -iq NVIDIA ; then
     NVIDIA_RT="--gpus all"
-    DOCK_IMG_NAME=$DOCK_IMG_NAME_NV
+    if [ "$(uname -m)" == "aarch64" ]; then
+        DOCK_IMG_NAME=$DOCK_IMG_NAME_NV_ARM
+    else
+        DOCK_IMG_NAME=$DOCK_IMG_NAME_NV
+    fi
 elif lspci | grep -iq AMD ; then
     DOCK_IMG_NAME=$DOCK_IMG_NAME_AMD
 else
-    DOCK_IMG_NAME=$DOCK_IMG_NAME_CPU
+    if [ "$(uname -m)" == "aarch64" ]; then
+        DOCK_IMG_NAME=$DOCK_IMG_NAME_NV_ARM
+    else
+        DOCK_IMG_NAME=$DOCK_IMG_NAME_CPU
+    fi
 fi
 
 WORKING_DIR="/azure-nhc"

--- a/test/data/nvbandwidth_v0.10_output.txt
+++ b/test/data/nvbandwidth_v0.10_output.txt
@@ -1,0 +1,26 @@
+Running host_to_device_memcpy_ce.
+memcpy CE CPU(row) -> GPU(column) bandwidth (GB/s)
+          0         1
+0     26.03     25.94
+
+SUM host_to_device_memcpy_ce 51.97
+COEFFICIENT_OF_VARIATION host_to_device_memcpy_ce 0.01
+NOTE: The reported results may not reflect the full capabilities of the platform.
+Performance can vary with software drivers, hardware clocks, and system topology.
+
+Running device_to_host_memcpy_ce.
+memcpy CE GPU(row) -> CPU(column) bandwidth (GB/s)
+          0         1
+0     25.97     26.00
+
+SUM device_to_host_memcpy_ce 51.97
+COEFFICIENT_OF_VARIATION device_to_host_memcpy_ce 0.02
+
+Running device_to_device_memcpy_read_ce.
+memcpy CE GPU(row) <- GPU(column) bandwidth (GB/s)
+          0         1
+0       N/A    276.07
+1    276.19       N/A
+
+SUM device_to_device_memcpy_read_ce 552.26
+COEFFICIENT_OF_VARIATION device_to_device_memcpy_read_ce 0.01

--- a/test/unit-tests/nhc-gpu-agnostic.sh
+++ b/test/unit-tests/nhc-gpu-agnostic.sh
@@ -3,7 +3,7 @@
 source ${AZ_NHC_ROOT:-$NHC_DIR}/test/unit-tests/nhc-test-common.sh
 source "$AZ_NHC_ROOT/customTests/azure_gpu_bandwidth.nhc"
 
-@test "Parse nvbandwidth v0.10 result matrices" {
+@test "check_nvBW_gpu_bw: Parse nvbandwidth v0.10 result matrices" {
     nvbandwidth_output=$(<"$AZ_NHC_ROOT/test/data/nvbandwidth_v0.10_output.txt")
 
     parse_nvbandwidth_results "$nvbandwidth_output" 2 "$H2D" "$D2H" "$P2P"
@@ -13,7 +13,7 @@ source "$AZ_NHC_ROOT/customTests/azure_gpu_bandwidth.nhc"
     [[ "${result_lines_array[$P2P]}" == $'0       N/A    276.07\n1    276.19       N/A' ]]
 }
 
-@test "Reject nvbandwidth output without a result matrix" {
+@test "check_nvBW_gpu_bw: Reject nvbandwidth output without a result matrix" {
     run parse_nvbandwidth_results \
         $'Running host_to_device_memcpy_ce.\nSUM host_to_device_memcpy_ce 51.97' \
         2 "$H2D"
@@ -21,7 +21,7 @@ source "$AZ_NHC_ROOT/customTests/azure_gpu_bandwidth.nhc"
     [[ "$status" -ne 0 ]]
 }
 
-@test "Reject an incomplete nvbandwidth result matrix" {
+@test "check_nvBW_gpu_bw: Reject an incomplete nvbandwidth result matrix" {
     nvbandwidth_output=$(<"$AZ_NHC_ROOT/test/data/nvbandwidth_v0.10_output.txt")
     nvbandwidth_output="${nvbandwidth_output//$'1    276.19       N/A\n'/}"
 

--- a/test/unit-tests/nhc-gpu-agnostic.sh
+++ b/test/unit-tests/nhc-gpu-agnostic.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+source ${AZ_NHC_ROOT:-$NHC_DIR}/test/unit-tests/nhc-test-common.sh
+source "$AZ_NHC_ROOT/customTests/azure_gpu_bandwidth.nhc"
+
+@test "Parse nvbandwidth v0.10 result matrices" {
+    nvbandwidth_output=$(<"$AZ_NHC_ROOT/test/data/nvbandwidth_v0.10_output.txt")
+
+    parse_nvbandwidth_results "$nvbandwidth_output" 2 "$H2D" "$D2H" "$P2P"
+
+    [[ "${result_lines_array[$H2D]}" == "0     26.03     25.94" ]]
+    [[ "${result_lines_array[$D2H]}" == "0     25.97     26.00" ]]
+    [[ "${result_lines_array[$P2P]}" == $'0       N/A    276.07\n1    276.19       N/A' ]]
+}
+
+@test "Reject nvbandwidth output without a result matrix" {
+    run parse_nvbandwidth_results \
+        $'Running host_to_device_memcpy_ce.\nSUM host_to_device_memcpy_ce 51.97' \
+        2 "$H2D"
+
+    [[ "$status" -ne 0 ]]
+}
+
+@test "Reject an incomplete nvbandwidth result matrix" {
+    nvbandwidth_output=$(<"$AZ_NHC_ROOT/test/data/nvbandwidth_v0.10_output.txt")
+    nvbandwidth_output="${nvbandwidth_output//$'1    276.19       N/A\n'/}"
+
+    run parse_nvbandwidth_results "$nvbandwidth_output" 2 "$H2D" "$D2H" "$P2P"
+
+    [[ "$status" -ne 0 ]]
+}

--- a/test/unit-tests/nhc-gpu-test.sh
+++ b/test/unit-tests/nhc-gpu-test.sh
@@ -14,6 +14,33 @@ for check in "${gpu_test[@]}" ; do
     source $AZ_NHC_ROOT/customTests/$check
 done
 
+@test "Parse nvbandwidth v0.10 result matrices" {
+    nvbandwidth_output=$(<"$AZ_NHC_ROOT/test/data/nvbandwidth_v0.10_output.txt")
+
+    parse_nvbandwidth_results "$nvbandwidth_output" 2 "$H2D" "$D2H" "$P2P"
+
+    [[ "${result_lines_array[$H2D]}" == "0     26.03     25.94" ]]
+    [[ "${result_lines_array[$D2H]}" == "0     25.97     26.00" ]]
+    [[ "${result_lines_array[$P2P]}" == $'0       N/A    276.07\n1    276.19       N/A' ]]
+}
+
+@test "Reject nvbandwidth output without a result matrix" {
+    run parse_nvbandwidth_results \
+        $'Running host_to_device_memcpy_ce.\nSUM host_to_device_memcpy_ce 51.97' \
+        2 "$H2D"
+
+    [[ "$status" -ne 0 ]]
+}
+
+@test "Reject an incomplete nvbandwidth result matrix" {
+    nvbandwidth_output=$(<"$AZ_NHC_ROOT/test/data/nvbandwidth_v0.10_output.txt")
+    nvbandwidth_output="${nvbandwidth_output//$'1    276.19       N/A\n'/}"
+
+    run parse_nvbandwidth_results "$nvbandwidth_output" 2 "$H2D" "$D2H" "$P2P"
+
+    [[ "$status" -ne 0 ]]
+}
+
 @test "Pass case: check_gpu_count" {
     set +e
     gpu_count=$(nvidia-smi --list-gpus | wc -l)

--- a/test/unit-tests/nhc-gpu-test.sh
+++ b/test/unit-tests/nhc-gpu-test.sh
@@ -81,7 +81,7 @@ done
 @test "Fail case: check_nccl_allreduce" {
     set +e
     topo_file=$(get_topofile)
-    result=$(check_nccl_allreduce 600.0 1 8G $topo_file)
+    result=$(check_nccl_allreduce 100000 1 8G $topo_file)
     set -e
     [[ "$result" == *"ERROR"* ]]
 }

--- a/test/unit-tests/nhc-gpu-test.sh
+++ b/test/unit-tests/nhc-gpu-test.sh
@@ -14,33 +14,6 @@ for check in "${gpu_test[@]}" ; do
     source $AZ_NHC_ROOT/customTests/$check
 done
 
-@test "Parse nvbandwidth v0.10 result matrices" {
-    nvbandwidth_output=$(<"$AZ_NHC_ROOT/test/data/nvbandwidth_v0.10_output.txt")
-
-    parse_nvbandwidth_results "$nvbandwidth_output" 2 "$H2D" "$D2H" "$P2P"
-
-    [[ "${result_lines_array[$H2D]}" == "0     26.03     25.94" ]]
-    [[ "${result_lines_array[$D2H]}" == "0     25.97     26.00" ]]
-    [[ "${result_lines_array[$P2P]}" == $'0       N/A    276.07\n1    276.19       N/A' ]]
-}
-
-@test "Reject nvbandwidth output without a result matrix" {
-    run parse_nvbandwidth_results \
-        $'Running host_to_device_memcpy_ce.\nSUM host_to_device_memcpy_ce 51.97' \
-        2 "$H2D"
-
-    [[ "$status" -ne 0 ]]
-}
-
-@test "Reject an incomplete nvbandwidth result matrix" {
-    nvbandwidth_output=$(<"$AZ_NHC_ROOT/test/data/nvbandwidth_v0.10_output.txt")
-    nvbandwidth_output="${nvbandwidth_output//$'1    276.19       N/A\n'/}"
-
-    run parse_nvbandwidth_results "$nvbandwidth_output" 2 "$H2D" "$D2H" "$P2P"
-
-    [[ "$status" -ne 0 ]]
-}
-
 @test "Pass case: check_gpu_count" {
     set +e
     gpu_count=$(nvidia-smi --list-gpus | wc -l)

--- a/test/unit-tests/run_tests.sh
+++ b/test/unit-tests/run_tests.sh
@@ -35,13 +35,19 @@ if lspci | grep -iq NVIDIA ; then
     NVIDIA_RT="--runtime=nvidia"
 fi
 
+if [ "$(uname -m)" == "aarch64" ]; then
+    DOCK_IMG_NAME="mcr.microsoft.com/aznhc/aznhc-nv:aarch64"
+else
+    DOCK_IMG_NAME="mcr.microsoft.com/aznhc/aznhc-nv"
+fi
+
 sudo docker run -itd --name=aznhc --net=host -e TIMEOUT=500 --rm \
 ${NVIDIA_RT} --cap-add SYS_ADMIN --cap-add=CAP_SYS_NICE \
 --shm-size=8g \
 --privileged \
 -v $NHC_DIR/customTests:/azure-nhc/customTests \
 -v $NHC_DIR/test:/azure-nhc/test \
-mcr.microsoft.com/aznhc/aznhc-nv bash
+${DOCK_IMG_NAME} bash
 
 sudo docker exec -it aznhc bash -c "cp /azure-nhc/customTests/azure_common.nhc /etc/nhc/scripts/"
 

--- a/test/unit-tests/run_tests_agnostic.sh
+++ b/test/unit-tests/run_tests_agnostic.sh
@@ -62,3 +62,4 @@ source "$NHC_DIR/test/unit-tests/nhc-test-common.sh"
 # Run Unit Tests
 bats --pretty "$NHC_DIR/test/unit-tests/nhc-hardware-test.sh"
 bats --pretty "$NHC_DIR/test/unit-tests/nhc-ib-test.sh"
+bats --pretty "$NHC_DIR/test/unit-tests/nhc-gpu-agnostic.sh"


### PR DESCRIPTION
## Summary

Adds an aarch64 NVIDIA health-check image for Azure Grace/Blackwell SKUs, including the nvbandwidth v0.10 parser compatibility required by that image.

## Changes

- Adds an Ubuntu 24.04, CUDA 13, ARM64 NVIDIA container image using DOCA-Host packages.
- Builds tools for the configured GB200 (`sm100`) and GB300 (`sm103`) CUDA architectures.
- Adds architecture-aware image build, pull, runtime, and test selection.
- Validates supported CPU architectures explicitly and rejects unsupported combinations.
- Documents the aarch64 container environment and GPUDirect RDMA host-module requirement.
- Updates `check_nvBW_gpu_bw` for nvbandwidth v0.10 output.

## nvbandwidth compatibility

The aarch64 image uses nvbandwidth v0.10, which emits `SUM`, `COEFFICIENT_OF_VARIATION`, and `NOTE` metadata after result matrices.

The previous parser allowed non-matrix output to reach bandwidth evaluation, which could produce bogus values or false failures. Parsing is now limited to complete numeric/N/A matrices with the expected dimensions for the detected GPU count and requested tests. Representative v0.10 output covers valid parsing and malformed or incomplete output rejection.

## Validation

- Built and started the aarch64 image on an Azure GB300 node.
- Validated NVIDIA tooling and automatic architecture-aware image selection.
- Added focused parser coverage for nvbandwidth v0.10 result matrices.